### PR TITLE
fix: four V8 strict-mode bugs found while testing v3.0 on Apple Silicon

### DIFF
--- a/lib/chat_ui.js
+++ b/lib/chat_ui.js
@@ -89,8 +89,15 @@ var pi2llmChatDialog = class extends Dialog {
                 // Trigger the same action as clicking the Send button.
                 this.submitUserInput();
 
-                // Tell the system we have handled this event completely.
-                key.accepted = true;
+                // Note: do NOT assign `key.accepted = true` here. In PJSR, the
+                // first argument to onKeyPress is an integer keycode (primitive
+                // number), not an event object. Under V8 strict mode, assigning
+                // a property to a primitive throws:
+                //   TypeError: Cannot create property 'accepted' on number 13
+                // Under SpiderMonkey the assignment was a silent no-op, which
+                // is why this previously appeared to work. PJSR consumes the
+                // synthesized Ctrl+Enter once submitUserInput() is invoked,
+                // so no explicit acceptance is needed.
             }
         }
     };

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -45,10 +45,16 @@ class ImagePreparer {
             }
             jpgInstance.close();
 
-            let file = new File();
-            file.openForReading(outputFilePath);
+            // Note: previously this block opened the temp file with
+            //   let file = new File();
+            //   file.openForReading(outputFilePath);
+            //   compressedData = File.readFile(outputFilePath);
+            //   file.close();
+            // The first two lines acquired a File handle that was never used
+            // (the bytes came from the static File.readFile, not from `file`),
+            // and the handle leaked on every vision request whenever the
+            // function returned early. File.readFile is sufficient on its own.
             compressedData = File.readFile(outputFilePath);
-            file.close();
 
             // Delete the temporary file.
             File.remove(outputFilePath);

--- a/pi2llm-main.js
+++ b/pi2llm-main.js
@@ -33,7 +33,10 @@ function LLMCommunicator(url, apiKey) {
  */
 function unicodeEscape(jsonString) {
     return jsonString.replace(/[\u007F-\uFFFF]/g, function(chr) {
-        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+        // String.prototype.substr is a legacy (Annex B) method, deprecated
+        // since ES2015 and scheduled for removal from V8. Use slice(-4)
+        // for forward compatibility.
+        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).slice(-4)
     });
 }
 

--- a/pi2llm-main.js
+++ b/pi2llm-main.js
@@ -290,15 +290,24 @@ LLMCommunicator.prototype.sendMessage = function (payload, onComplete, onError) 
             // 3. Cloudflare AI Gateway: {"result":{"response":"..."}}
             } else if (responseObject && responseObject.result) {
                 messageContent = responseObject.result.response;
-            // 4. Generic error array: [{"error":{"code":..., "message":..., "status":...}}]
+            // 4. Generic error response. The body may arrive as either:
+            //      a) An array wrapping the error object (Google PaLM/Gemini
+            //         legacy style): [{"error":{"code":..., "message":..., "status":...}}]
+            //      b) A plain object with an "error" key (OpenAI, Anthropic,
+            //         most OpenAI-compatible providers).
+            //    Unwrap defensively so a non-array body does not crash with
+            //    "Cannot read properties of undefined (reading 'error')".
             } else if (responseObject && transfer.responseCode > 200) {
-                let errorObject = responseObject[0];
-                var error = errorObject.error;
-                var errorMsg = error.message
-                var errorCode = error.code;
-                var errorStatus = error.status;
-
-                messageContent = "AI Error: " + errorMsg + ", code: " + errorCode + ", status: " + errorStatus;
+                let errorObject = Array.isArray(responseObject) ? responseObject[0] : responseObject;
+                let error = (errorObject && errorObject.error) ? errorObject.error : null;
+                if (error) {
+                    let errorMsg = error.message || "(no message)";
+                    let errorCode = (error.code !== undefined) ? error.code : "(no code)";
+                    let errorStatus = error.status || "(no status)";
+                    messageContent = "AI Error: " + errorMsg + ", code: " + errorCode + ", status: " + errorStatus;
+                } else {
+                    messageContent = "AI Error: HTTP " + transfer.responseCode + " (unrecognized error body)";
+                }
             }
             if (onComplete) {
                 onComplete(messageContent);


### PR DESCRIPTION
Found these while testing v3.0 on PixInsight 1.9.4.0 ARM64 (Apple Silicon, M2 Max). Each is a small, self-contained V8 strict-mode bug that the legacy SpiderMonkey runtime silently tolerated. They're split into four commits so you can cherry-pick or reject individually.

**Tested on:** macOS 15.x, Mac Studio M2 Max, PixInsight 1.9.4.0 ARM64 (native), local LM Studio server (OpenAI-compatible, qwen2.5-vl-7b-instruct).

### Commits

1. **`fix(chat_ui): remove invalid key.accepted assignment on numeric keycode`**
   PJSR passes the keycode to `onKeyPress` as a primitive `number`. Assigning `.accepted = true` to it throws `TypeError: Cannot create property 'accepted' on number 13` under V8 strict mode. The synthesised Ctrl+Enter is already consumed by `submitUserInput()`, so the assignment is unnecessary.

2. **`fix(unicodeEscape): replace deprecated String.prototype.substr with slice`**
   `substr` is an Annex B (legacy) method scheduled for removal from V8. `slice(-4)` is behaviour-equivalent for this call site.

3. **`fix(error-path): defensively unwrap error response body`**
   The generic error path assumed `responseObject` was always an array (Google PaLM/Gemini legacy shape), but most providers (OpenAI, Anthropic, OpenAI-compatible servers) return a plain object. When the body was an object, `responseObject[0]` was `undefined` and the next line crashed. Fix detects array vs object with `Array.isArray` and null-guards the `.error` read.

4. **`fix(extractors): remove redundant File.openForReading on vision temp file`**
   The vision-prep path acquired a `File` handle that was never used (the bytes came from the static `File.readFile`). The handle leaked on every early-return path. Removed.

### Notes

- No behaviour changes to UI, network protocol, or `chat_ui.js` class structure — all four are localized to the bug site plus a defensive guard.
- No new dependencies, no syntax outside what v3.0 already uses.
- Happy to split, rebase, or reword commit messages however you'd prefer.

Thanks again for the v3.0 V8 port — it's been working great for general use on Apple Silicon and this is what fell out of stress-testing it.
